### PR TITLE
Fix pod anti affinity for unleash

### DIFF
--- a/openshift/unleash.yaml
+++ b/openshift/unleash.yaml
@@ -25,6 +25,18 @@ objects:
         labels:
           app: ${identifier}
       spec:
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: app
+                  operator: In
+                  values:
+                  - unleash
+              topologyKey: "kubernetes.io/hostname"
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always

--- a/openshift/unleash.yaml
+++ b/openshift/unleash.yaml
@@ -28,8 +28,7 @@ objects:
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
+          - podAffinityTerm:
               labelSelector:
                 matchExpressions:
                 - key: app
@@ -37,6 +36,7 @@ objects:
                   values:
                   - unleash
               topologyKey: "kubernetes.io/hostname"
+            weight: 100
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always


### PR DESCRIPTION
This work is to clear DVO alerts for unleash. Part of [APPSRE-4966](https://issues.redhat.com/browse/APPSRE-4966) and [APPSRE-5350](https://issues.redhat.com/browse/APPSRE-5350)