### PR TITLE
fixing labelSelector value for affinity to clear DVO alerts

### DIFF
--- a/openshift/unleash.yaml
+++ b/openshift/unleash.yaml
@@ -32,7 +32,8 @@ objects:
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
-            - podAffinityTerm:
+            - weight: 100
+              podAffinityTerm:
                 labelSelector:
                   matchExpressions:
                   - key: app
@@ -40,7 +41,6 @@ objects:
                     values:
                     - unleash
                 topologyKey: "kubernetes.io/hostname"
-              weight: 100
         serviceAccountName: unleash
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}

--- a/openshift/unleash.yaml
+++ b/openshift/unleash.yaml
@@ -38,10 +38,7 @@ objects:
                   - key: app
                     operator: In
                     values:
-                    - app-interface
-                    - insights
-                    - ocm
-                    - managed-services
+                    - ${identifier}
                 topologyKey: "kubernetes.io/hostname"
               weight: 100
         serviceAccountName: unleash

--- a/openshift/unleash.yaml
+++ b/openshift/unleash.yaml
@@ -32,15 +32,18 @@ objects:
         affinity:
           podAntiAffinity:
             preferredDuringSchedulingIgnoredDuringExecution:
-            - weight: 100
-              podAffinityTerm:
+            - podAffinityTerm:
                 labelSelector:
                   matchExpressions:
                   - key: app
                     operator: In
                     values:
-                    - unleash
+                    - app-interface
+                    - insights
+                    - ocm
+                    - managed-services
                 topologyKey: "kubernetes.io/hostname"
+              weight: 100
         serviceAccountName: unleash
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}


### PR DESCRIPTION
It looks like the [DVO alerts](https://grafana.stage.devshift.net/d/dashdotdb/dash-db?orgId=1&var-datasource=dashdotdb-rds&var-cluster=app-sre-stage-01&var-namespace=unleash) did not clear up for unleash regarding anti affinity. Continuation of this [PR](https://github.com/app-sre/unleash/commit/007e148980434800cc14f62126c0f465abdd0938) and this [PR](https://github.com/app-sre/unleash/commit/95f5156426a1209db743f945c65585875ab8cfba).

Signed-off-by: Suzana Nesic <snesic@redhat.com>