### PR TITLE
add read only access permission team

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ to be provided:
 User validation:
 
 - `ORG`: The Github organization users have to be member of.
-- `TEAM`: The Github organization team users have to be member of.
+- `TEAM`: The Github organization team users have to be member of to be admin in Unleash
+- `READ_ONLY_TEAM`: The Github organization team users have to be member of to have read only access to Unleash
 
 Database:
 

--- a/openshift/unleash.yaml
+++ b/openshift/unleash.yaml
@@ -51,6 +51,8 @@ objects:
               value: ${org}
             - name: TEAM
               value: ${team}
+            - name: READ_ONLY_TEAM
+              value: ${read_only_team}
             - name: DATABASE_HOST
               valueFrom:
                  secretKeyRef:
@@ -178,4 +180,4 @@ parameters:
   value: app-sre
 - name: team
   value: app-sre-cluster
-- name: read-only-team
+- name: read_only_team

--- a/openshift/unleash.yaml
+++ b/openshift/unleash.yaml
@@ -178,3 +178,4 @@ parameters:
   value: app-sre
 - name: team
   value: app-sre-cluster
+- name: read-only-team


### PR DESCRIPTION
by adding an additional env variable `READ_ONLY_TEAM`, a github org group can be specified to have to have `Viewer` permissions instead of the default `Editor` permissions.
if a user is in both the `TEAM` and the `READ_ONLY_TEAM`, the `Editor` permissions from `TEAM` have precedence.

https://docs.getunleash.io/user_guide/rbac

part of https://issues.redhat.com/browse/APPSRE-5704

Signed-off-by: Gerd Oberlechner <goberlec@redhat.com>