### PR TITLE
unique ServiceAccount per instance

### DIFF
--- a/openshift/unleash.yaml
+++ b/openshift/unleash.yaml
@@ -7,7 +7,7 @@ objects:
 - apiVersion: v1
   kind: ServiceAccount
   metadata:
-    name: unleash
+    name: ${identifier}
 - apiVersion: apps/v1
   kind: Deployment
   metadata:
@@ -41,7 +41,7 @@ objects:
                     - ${identifier}
                 topologyKey: "kubernetes.io/hostname"
               weight: 100
-        serviceAccountName: unleash
+        serviceAccountName: ${identifier}
         containers:
         - image: ${IMAGE}:${IMAGE_TAG}
           imagePullPolicy: Always


### PR DESCRIPTION
currently all instances within the same namespace are sharing a single ServiceAccount called `unleash`.
instances are basically fighting over the SA.

with this PR, each instance will be created with it's own SA.