### PR TITLE
[APPSRE-7594] drop `BEARER` requirement from authorization header

### DIFF
--- a/index.js
+++ b/index.js
@@ -130,7 +130,7 @@ function adminAuth(app, config, services) {
   });
 
   app.use('/api/client', (req, res, next) => {
-    if (req.header('authorization') === `Bearer ${CLIENT_ACCESS_TOKEN}`) || (req.header('authorization') === `${ADMIN_ACCESS_TOKEN}`) {
+    if (req.header('authorization') === `Bearer ${CLIENT_ACCESS_TOKEN}`) || (req.header('authorization') === `${CLIENT_ACCESS_TOKEN}`) {
       next();
      } else {
        res.sendStatus(401);

--- a/index.js
+++ b/index.js
@@ -113,7 +113,7 @@ function adminAuth(app, config, services) {
   app.use('/api/admin/', (req, res, next) => {
     if (req.user) {
       next();
-    } else if (req.header('authorization') === `Bearer ${ADMIN_ACCESS_TOKEN}`) {
+    } else if (req.header('authorization') === `Bearer ${ADMIN_ACCESS_TOKEN}`) || (req.header('authorization') === `${ADMIN_ACCESS_TOKEN}`) {
       next();
     } else {
       return res
@@ -130,7 +130,7 @@ function adminAuth(app, config, services) {
   });
 
   app.use('/api/client', (req, res, next) => {
-    if (req.header('authorization') === `Bearer ${CLIENT_ACCESS_TOKEN}`) {
+    if (req.header('authorization') === `Bearer ${CLIENT_ACCESS_TOKEN}`) || (req.header('authorization') === `${ADMIN_ACCESS_TOKEN}`) {
       next();
      } else {
        res.sendStatus(401);


### PR DESCRIPTION
Vanilla Unleash 4.x does not accept an Authorization header that includes `BEARER`. Because the app-sre instance requires Bearer, the client configuration is not compatible with an Unleash used locally for dev purposes.