### PR TITLE
Move pko build inside container

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -22,10 +22,12 @@ docker --config="${DOCKER_CONF}" push "${IMAGE_NAME}:${IMAGE_TAG}"
 docker --config="${DOCKER_CONF}" push "${IMAGE_NAME}:${INTEGRATION_TEST_IMAGE_TAG_PREFIX}${IMAGE_TAG}"
 
 # build and push PKO image
-docker build -t "pko-build:latest" -f pko/Dockerfile --build-arg="PKO_IMAGE_NAME=$PKO_IMAGE_NAME" --build-arg="IMAGE_TAG=$IMAGE_TAG" ./pko
-docker create --name pko-build pko-build:latest
-docker cp pko-build:/tmp/image.tgz pko/image.tgz
-docker rm pko-build
+PKO_BUILD_IMAGE="pko-build:${IMAGE_TAG}"
+PKO_BUILD_CONTAINER="pko-build-${IMAGE_TAG}"
+docker build -t "$PKO_BUILD_IMAGE" -f pko/Dockerfile --build-arg="PKO_IMAGE_NAME=$PKO_IMAGE_NAME" --build-arg="IMAGE_TAG=$IMAGE_TAG" ./pko
+docker create --name "$PKO_BUILD_CONTAINER" "$PKO_BUILD_IMAGE"
+docker cp "$PKO_BUILD_CONTAINER":/tmp/image.tgz pko/image.tgz
+docker rm "$PKO_BUILD_CONTAINER"
 docker load < pko/image.tgz
 docker --config="${DOCKER_CONF}" push "${PKO_IMAGE_NAME}:latest"
 docker --config="${DOCKER_CONF}" push "${PKO_IMAGE_NAME}:${IMAGE_TAG}"

--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -22,9 +22,10 @@ docker --config="${DOCKER_CONF}" push "${IMAGE_NAME}:${IMAGE_TAG}"
 docker --config="${DOCKER_CONF}" push "${IMAGE_NAME}:${INTEGRATION_TEST_IMAGE_TAG_PREFIX}${IMAGE_TAG}"
 
 # build and push PKO image
-cp -R $PWD/pko/package/ ${PWD}/pko/tmp
-docker run -v .:/unleash:z quay.io/app-sre/ubi8-ubi-minimal:8.8 sed -i "s/UNLEASH_IMAGE_TAG/$IMAGE_TAG/g" /unleash/pko/tmp/manifest.yaml
-docker run -v .:/unleash:z quay.io/app-sre/package-operator-cli:92430cd build -t "${PKO_IMAGE_NAME}:${IMAGE_TAG}" -t "${PKO_IMAGE_NAME}:latest" /unleash/pko/tmp -o /unleash/pko/image.tgz
+docker build -t "pko-build:latest" -f pko/Dockerfile --build-arg="PKO_IMAGE_NAME=$PKO_IMAGE_NAME" --build-arg="IMAGE_TAG=$IMAGE_TAG" ./pko
+docker create --name pko-build pko-build:latest
+docker cp pko-build:/tmp/image.tgz pko/image.tgz
+docker rm pko-build
 docker load < pko/image.tgz
 docker --config="${DOCKER_CONF}" push "${PKO_IMAGE_NAME}:latest"
 docker --config="${DOCKER_CONF}" push "${PKO_IMAGE_NAME}:${IMAGE_TAG}"

--- a/pko/.dockerignore
+++ b/pko/.dockerignore
@@ -1,0 +1,1 @@
+image.tgz

--- a/pko/Dockerfile
+++ b/pko/Dockerfile
@@ -1,0 +1,17 @@
+ARG PKO_IMAGE_NAME=quay.io/app-sre/unleash-pko
+ARG IMAGE_TAG=latest
+
+FROM quay.io/app-sre/package-operator-cli:92430cd as base
+WORKDIR /tmp
+COPY . .
+
+FROM base as test
+RUN /kubectl-package validate ./package
+RUN /kubectl-package tree ./package --config-path ./validation_config.yaml
+
+FROM base
+ARG PKO_IMAGE_NAME
+ARG IMAGE_TAG
+USER 0
+RUN sed -i "s/UNLEASH_IMAGE_TAG/$IMAGE_TAG/g" ./package/manifest.yaml
+RUN /kubectl-package build -t "${PKO_IMAGE_NAME}:${IMAGE_TAG}" -t "${PKO_IMAGE_NAME}:latest" ./package -o image.tgz

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -3,12 +3,12 @@
 IMAGE_TEST=unleash-test
 IMAGE_INTEGRATION_TEST=unleash-integration-test
 K6_IMAGE="quay.io/app-sre/k6"
+PKO_BUILD_TEST=pko-build-test
 
 # Let's just build the image. That's enough test for now.
 docker build -t ${IMAGE_TEST} -f Dockerfile .
 docker build -t ${IMAGE_INTEGRATION_TEST} -f integration_test/Dockerfile --build-arg="K6_IMAGE=$K6_IMAGE" ./integration_test
 
 # Validate package
-docker run -v .:/unleash:z quay.io/app-sre/package-operator-cli:92430cd validate /unleash/pko/package
-docker run -v .:/unleash:z quay.io/app-sre/package-operator-cli:92430cd tree /unleash/pko/package --config-path /unleash/pko/validation_config.yaml
+docker build --target test -t ${PKO_BUILD_TEST} -f pko/Dockerfile ./pko
 # todo - use test feature


### PR DESCRIPTION
pko build was broken on CI because of volume mount permission

```
Error: building from source: exporting package to file: dump to /unleash/pko/image.tgz: open /unleash/pko/image.tgz: permission denied
```

Move everything inside container and use `docker cp` to extract build artifacts to avoid *it's working on my machine*.