### PR TITLE
Zero downtime deployment

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 IMAGE_NAME="quay.io/app-sre/unleash"
 PKO_IMAGE_NAME="quay.io/app-sre/unleash-pko"
 INTEGRATION_TEST_IMAGE_TAG_PREFIX="integration-test-"

--- a/openshift/unleash.yaml
+++ b/openshift/unleash.yaml
@@ -132,21 +132,22 @@ objects:
             limits:
               memory: ${MEMORY_LIMIT}
           readinessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            tcpSocket:
-              port: 4242
-            timeoutSeconds: 1
+            httpGet:
+              path: /health
+              port: unleash
+              initialDelaySeconds: 30
+              timeoutSeconds: 10
+              successThreshold: 5
           livenessProbe:
-            failureThreshold: 3
-            initialDelaySeconds: 5
-            periodSeconds: 10
-            successThreshold: 1
-            tcpSocket:
-              port: 4242
-            timeoutSeconds: 1
+            httpGet:
+              path: /health
+              port: unleash
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+          lifecycle:
+            preStop:
+              exec:
+                command: [ "sleep", "10" ]
 - apiVersion: v1
   kind: Service
   metadata:

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 IMAGE_TEST=unleash-test
 IMAGE_INTEGRATION_TEST=unleash-integration-test
 K6_IMAGE="quay.io/app-sre/k6"


### PR DESCRIPTION
Use the same probe config as [official ones](https://github.com/Unleash/helm-charts/blob/main/charts/unleash/values.yaml) to avoid ready in k8s but not ready to serve traffic.

Add delay to shutdown to avoid pod deleted before route info updated, similar to https://github.com/app-sre/qontract-server/pull/197, docs:
* [Graceful shutdown and zero downtime deployments in Kubernetes](https://learnk8s.io/graceful-shutdown)
* [Kubernetes Container Lifecycle](https://docs.spring.io/spring-boot/docs/current/reference/html/deployment.html#deployment.cloud.kubernetes.container-lifecycle)

Also make scripts check strict, to avoid pipeline pass, but there are errors in it (happened once today).

[APPSRE-8125](https://issues.redhat.com/browse/APPSRE-8125)