### PR TITLE
Update .dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,4 @@ keycloak_data
 openshift
 pko
 integration_test
+.docker


### PR DESCRIPTION
Updates `.dockerignore` file to not copy over files from a `.docker` folder which include sensitive credentials.