### PR TITLE
APPSRE-11226: update integration dockerfile

### DIFF
--- a/build_deploy.sh
+++ b/build_deploy.sh
@@ -5,7 +5,6 @@ set -euo pipefail
 IMAGE_NAME="quay.io/app-sre/unleash"
 PKO_IMAGE_NAME="quay.io/app-sre/unleash-pko"
 INTEGRATION_TEST_IMAGE_TAG_PREFIX="integration-test-"
-K6_IMAGE="quay.io/app-sre/k6"
 IMAGE_TAG=$(git rev-parse --short=7 HEAD)
 
 DOCKER_CONF="${PWD}/.docker"
@@ -18,7 +17,6 @@ docker tag "${IMAGE_NAME}:latest" "${IMAGE_NAME}:${IMAGE_TAG}"
 
 docker --config="${DOCKER_CONF}" build -t "${IMAGE_NAME}:${INTEGRATION_TEST_IMAGE_TAG_PREFIX}${IMAGE_TAG}" \
                                        -f integration_test/Dockerfile \
-                                       --build-arg="K6_IMAGE=$K6_IMAGE" \
                                        ./integration_test
 
 docker --config="${DOCKER_CONF}" push "${IMAGE_NAME}:latest"

--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -1,5 +1,7 @@
 FROM registry.access.redhat.com/ubi9/ubi:9.6-1749542372 as downloader
+
 ENV K6_VERSION=0.47.0
+
 RUN mkdir -p /tmp/k6 && \
     curl -sfL https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-amd64.tar.gz \
     | tar -zxf - -C /tmp/k6 --strip-components=1 && \
@@ -7,7 +9,6 @@ RUN mkdir -p /tmp/k6 && \
 
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1749489516
-COPY --chown=0:0 --from=downloader \
-     /tmp/k6/k6 /usr/local/bin/k6
+COPY --from=downloader /tmp/k6/k6 /usr/local/bin/k6
 COPY test.js /test.js
 CMD ["k6","run", "/test.js"]

--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -1,6 +1,9 @@
-ARG K6_IMAGE=grafana/k6
 
-FROM ${K6_IMAGE}:0.47.0
+ARG K6_VERSION=0.47.0
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1749542372
+RUN curl -sfL https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-amd64.tar.gz \
+    | tar -zxf - -C /usr/local/bin --strip-components=1 && \
+    rm -rf k6-v${K6_VERSION}-linux-amd64
 
 COPY test.js test.js
 

--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -1,9 +1,15 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.6-1749542372
+FROM registry.access.redhat.com/ubi9/ubi:9.6-1749542372 as downloader
 ENV K6_VERSION=0.47.0
-RUN curl -sfL https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-amd64.tar.gz \
-    | tar -zxf - -C /usr/local/bin --strip-components=1 && \
+RUN mkdir -p /tmp/k6 && \
+    curl -sfL https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-amd64.tar.gz \
+    | tar -zxf - -C /tmp/k6 --strip-components=1 && \
+    chmod +x /tmp/k6/k6 && \
     rm -rf k6-v${K6_VERSION}-linux-amd64
 
+
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1749489516
+COPY --chown=0:0 --from=downloader \
+     /tmp/k6 /usr/local/bin
 COPY test.js test.js
 
 CMD ["run", "test.js"]

--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -3,13 +3,11 @@ ENV K6_VERSION=0.47.0
 RUN mkdir -p /tmp/k6 && \
     curl -sfL https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-amd64.tar.gz \
     | tar -zxf - -C /tmp/k6 --strip-components=1 && \
-    chmod +x /tmp/k6/k6 && \
-    rm -rf k6-v${K6_VERSION}-linux-amd64
+    chmod +x /tmp/k6/k6 
 
 
 FROM registry.access.redhat.com/ubi9/ubi-minimal:9.6-1749489516
 COPY --chown=0:0 --from=downloader \
-     /tmp/k6 /usr/local/bin
-COPY test.js test.js
-
-CMD ["run", "test.js"]
+     /tmp/k6/k6 /usr/local/bin/k6
+COPY test.js /test.js
+CMD ["k6","run", "/test.js"]

--- a/integration_test/Dockerfile
+++ b/integration_test/Dockerfile
@@ -1,6 +1,5 @@
-
-ARG K6_VERSION=0.47.0
 FROM registry.access.redhat.com/ubi9/ubi:9.6-1749542372
+ENV K6_VERSION=0.47.0
 RUN curl -sfL https://github.com/grafana/k6/releases/download/v${K6_VERSION}/k6-v${K6_VERSION}-linux-amd64.tar.gz \
     | tar -zxf - -C /usr/local/bin --strip-components=1 && \
     rm -rf k6-v${K6_VERSION}-linux-amd64

--- a/pr_check.sh
+++ b/pr_check.sh
@@ -4,7 +4,6 @@ set -euo pipefail
 
 IMAGE_TEST=unleash-test
 IMAGE_INTEGRATION_TEST=unleash-integration-test
-K6_IMAGE="quay.io/app-sre/k6"
 PKO_BUILD_TEST=pko-build-test
 
 DOCKER_CONF="${PWD}/.docker"
@@ -20,6 +19,5 @@ docker --config="${DOCKER_CONF}" build --target test -t ${PKO_BUILD_TEST} -f pko
 docker --config="${DOCKER_CONF}" build -t ${IMAGE_TEST} -f Dockerfile .
 docker --config="${DOCKER_CONF}" build -t ${IMAGE_INTEGRATION_TEST} \
                                        -f integration_test/Dockerfile \
-                                       --build-arg="K6_IMAGE=$K6_IMAGE" \
                                        ./integration_test
 docker --config="${DOCKER_CONF}" build -t ${PKO_BUILD_TEST} -f pko/Dockerfile ./pko


### PR DESCRIPTION
PR consists of code changes to use k6 binary instead of the docker image for integration test.
After making the changes verified using 
`podman-compose up --build test`
execution was successful